### PR TITLE
Feature Review ahead when all cards are reviewed today

### DIFF
--- a/app/src/androidTest/java/com/faust/m/flashcardm/framework/db/room/CardRoomDataSourceTest.kt
+++ b/app/src/androidTest/java/com/faust/m/flashcardm/framework/db/room/CardRoomDataSourceTest.kt
@@ -9,6 +9,7 @@ import com.faust.m.flashcardm.framework.db.room.model.*
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.*
@@ -285,5 +286,119 @@ class CardRoomDataSourceTest: BaseDaoTest() {
                 id = 3
             ))
         }
+    }
+
+    @Test
+    fun testResetCardForReviewShouldMakeCardsAvailableForReview() {
+        givenABookletAnd4CardsNotForReviewWithDifferentRating()
+
+        // When I reset 2 cards for review
+        cardRoomDataSource.resetForReview(2, 25)
+
+        // There should be 2 card for review
+        cardRoomDataSource.getAllCardsForBooklet(25).filter(Card::needReview).run {
+            assertThat(size).`as`("There should be 2 card for review").isEqualTo(2)
+        }
+    }
+
+    private fun givenABookletAnd4CardsNotForReviewWithDifferentRating() {
+        bookletDao.add(bookletEntity)
+        cardDao.add(CardEntity(4, Date(), Date(20),25, 1))
+        cardDao.add(CardEntity(2, Date(), Date(20),25, 2))
+        cardDao.add(CardEntity(1, Date(), Date(20),25, 3))
+        cardDao.add(CardEntity(3, Date(), Date(20),25, 4))
+
+        cardRoomDataSource
+            .getAllCardsForBooklet(25)
+            .filter(Card::needReview)
+            .run {
+                assumeTrue("There should be no card to review yet", size == 0)
+            }
+    }
+
+    @Test
+    fun testResetCardForReviewShouldResetLowRatingCardFirst() {
+        givenABookletAnd4CardsNotForReviewWithDifferentRating()
+
+        // When I reset cards for review
+        cardRoomDataSource.resetForReview(2, 25)
+
+        // The cards for review should be the one with lowest rating
+        cardRoomDataSource
+            .getAllCardsForBooklet(25)
+            .filter(Card::needReview)
+            .run {
+                assertThat(this.map { it.rating }).containsExactlyInAnyOrder(1, 2)
+            }
+    }
+
+    @Test
+    fun testResetCardForReviewWhenNotEnoughCardShouldResetAsManyCardsAsPossible() {
+        givenABookletAnd4CardsNotForReviewWithDifferentRating()
+
+        // When I try to reset more card than possible
+        cardRoomDataSource.resetForReview(5, 25)
+
+        // All cards should be reset
+        cardRoomDataSource
+            .getAllCardsForBooklet(25)
+            .filter(Card::needReview)
+            .run {
+                assertThat(size).`as`("All card should need review").isEqualTo(4)
+            }
+    }
+
+    @Test
+    fun testResetCardForReviewShouldResetRatingUnder5IfNecessaryToMakeEnoughCardsForReview() {
+        // Given a booklet with 2 card (one with rating 5, so unelectable for review normally)
+        bookletDao.add(bookletEntity)
+        cardDao.add(CardEntity(5, Date(), Date(20),25, 1))
+        cardDao.add(CardEntity(2, Date(), Date(20),25, 2))
+
+        cardRoomDataSource
+            .getAllCardsForBooklet(25)
+            .filter(Card::needReview)
+            .run {
+                assumeTrue("There should be no card to review yet", size == 0)
+            }
+
+        // When I try to reset 2 cards for review
+        cardRoomDataSource.resetForReview(2, 25)
+
+        // The card with rating 5 should have dropped to 4 (rating 2 should stay the same)
+        cardRoomDataSource
+            .getAllCardsForBooklet(25)
+            .filter(Card::needReview)
+            .run {
+                assertThat(this.map { it.rating }).containsExactlyInAnyOrder(2, 4)
+            }
+    }
+
+    @Test
+    fun testResetCardForReviewShouldResetOnlyCardThatAreNotForReviewNow() {
+        // Given a booklet with 3 cards (one already in review state)
+        bookletDao.add(bookletEntity)
+        cardDao.add(CardEntity(3, Date(30), Date(20),25, 1))
+        cardDao.add(CardEntity(4, Date(), Date(20),25, 2))
+        cardDao.add(CardEntity(4, Date(), Date(20),25, 3))
+
+        cardRoomDataSource
+            .getAllCardsForBooklet(25)
+            .filter(Card::needReview)
+            .run {
+                assumeTrue("There should be one card for review already", size == 1)
+            }
+
+        // When I try to reset 1 card for review
+        cardRoomDataSource.resetForReview(1, 25)
+
+        // There should be 2 cards for review now (the previous one,
+        // plus the one that was just changed)
+        cardRoomDataSource
+            .getAllCardsForBooklet(25)
+            .filter(Card::needReview)
+            .run {
+                assertThat(size).`as`("There should be 2 cards to review yet").isEqualTo(2)
+            }
     }
 }

--- a/app/src/main/java/com/faust/m/flashcardm/framework/BookletUseCases.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/framework/BookletUseCases.kt
@@ -7,5 +7,6 @@ class BookletUseCases(val addBooklet: AddBooklet,
                       val getBooklet: GetBooklet,
                       val getBooklets: GetBooklets,
                       val getBookletsOutlines: GetBookletsOutlines,
-                      val renameBooklet: RenameBooklet
+                      val renameBooklet: RenameBooklet,
+                      val resetForReview: ResetForReview
 )

--- a/app/src/main/java/com/faust/m/flashcardm/framework/KoinModules.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/framework/KoinModules.kt
@@ -59,6 +59,7 @@ val bookletUseCases = module {
     single { GetBooklets(get()) }
     single { GetBookletsOutlines(get()) }
     single { RenameBooklet(get()) }
-    single { BookletUseCases(get(), get(), get(), get(), get(), get()) }
+    single { ResetForReview(get()) }
+    single { BookletUseCases(get(), get(), get(), get(), get(), get(), get()) }
 
 }

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/PresentationExtensions.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/PresentationExtensions.kt
@@ -18,7 +18,7 @@ fun View.setNoArgOnClickListener(listener: () -> Unit) {
     setOnClickListener {_ -> listener.invoke()}
 }
 
-fun AlertDialog.Builder.setPositiveButton(textId: Int, listener: () -> Unit): AlertDialog.Builder {
+fun AlertDialog.Builder.setNoArgPositiveButton(textId: Int, listener: () -> Unit): AlertDialog.Builder {
     return setPositiveButton(textId) { _, _ -> listener.invoke() }
 }
 

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/library/FragmentNameBooklet.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/library/FragmentNameBooklet.kt
@@ -12,7 +12,7 @@ import com.faust.m.flashcardm.R
 import com.faust.m.flashcardm.presentation.BaseViewModelFactory
 import com.faust.m.flashcardm.presentation.EditorAction
 import com.faust.m.flashcardm.presentation.setEditorActionListener
-import com.faust.m.flashcardm.presentation.setPositiveButton
+import com.faust.m.flashcardm.presentation.setNoArgPositiveButton
 import com.google.android.material.textfield.TextInputEditText
 import org.koin.android.ext.android.getKoin
 
@@ -48,7 +48,7 @@ class FragmentNameBooklet : DialogFragment() {
             _dialog = AlertDialog.Builder(it)
                 .setTitle(titleStringId)
                 .setView(rootView)
-                .setPositiveButton(positiveButtonStringId, ::onPositiveButtonClicked)
+                .setNoArgPositiveButton(positiveButtonStringId, ::onPositiveButtonClicked)
                 .setNegativeButton(android.R.string.cancel) { _, _ -> dismiss() }
                 .create()
 

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/library/FragmentReviewAhead.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/library/FragmentReviewAhead.kt
@@ -1,0 +1,126 @@
+package com.faust.m.flashcardm.presentation.library
+
+import android.app.Dialog
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.WindowManager.LayoutParams
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import com.faust.m.flashcardm.R
+import com.faust.m.flashcardm.presentation.BaseViewModelFactory
+import com.faust.m.flashcardm.presentation.EditorAction
+import com.faust.m.flashcardm.presentation.library.FragmentReviewAhead.CountValidationState.*
+import com.faust.m.flashcardm.presentation.setEditorActionListener
+import com.faust.m.flashcardm.presentation.setNoArgPositiveButton
+import com.google.android.material.textfield.TextInputEditText
+import org.jetbrains.anko.find
+import org.koin.android.ext.android.getKoin
+
+const val DEFAULT_REVIEW_AHEAD_CARD_NUMBER = 20
+
+class FragmentReviewAhead : DialogFragment() {
+
+    private lateinit var editNumber: TextInputEditText
+    private var _dialog: AlertDialog? = null
+    private lateinit var viewModel: LibraryViewModel
+    private var maxCardCount = 0
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        viewModel = getKoin().get<BaseViewModelFactory>().createViewModelFrom(this)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        // Create dialog
+        return activity?.let {
+            val rootView =
+                it.layoutInflater.inflate(R.layout.dialog_review_ahead, null)
+            editNumber = rootView.find(R.id.et_number_card_to_review_ahead)
+            editNumber.setEditorActionListener(::onEditorAction)
+            // TODO: could probably refactor this as it is duplicated code from FragmentNameBooklet
+            editNumber.addTextChangedListener(ValidationTextWatcher())
+
+            // Build dialog
+            _dialog = AlertDialog.Builder(it)
+                .setTitle(R.string.title_dialog_review_ahead)
+                .setView(rootView)
+                .setNoArgPositiveButton(R.string.confirm_review_card, ::onPositiveButtonClicked)
+                .setNegativeButton(android.R.string.cancel) { _, _ -> dismiss() }
+                .create()
+
+            // Use dialog window to focus on edit text and show soft input keyboard
+            editNumber.requestFocus()
+            _dialog?.window?.setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_VISIBLE)
+
+            _dialog
+        } ?: throw IllegalStateException("Activity cannot be null")
+
+    }
+
+    private fun onPositiveButtonClicked() {
+        editNumber.text.toString().toIntOrNull()?.let {
+            viewModel.addCardsToReviewAheadForCurrentBooklet(it)
+        }
+    }
+
+    private fun onEditorAction(textView: TextView, editorAction: EditorAction): Boolean {
+        textView.text.toString().let { count ->
+            if (editorAction.isDone() && count.validationState() == VALID) {
+                viewModel.addCardsToReviewAheadForCurrentBooklet(count.toInt())
+                dismiss()
+                return true
+            }
+            return false
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        viewModel.selectedBooklet?.let { maxCardCount = it.totalCardCount - it.cardToReviewCount}
+        maxCardCount
+            .coerceAtMost(DEFAULT_REVIEW_AHEAD_CARD_NUMBER)
+            .toString()
+            .let { defaultCardCount ->
+                editNumber.setText(defaultCardCount)
+                editNumber.setSelection(0, defaultCardCount.length)
+            }
+    }
+
+
+    private inner class ValidationTextWatcher: TextWatcher {
+
+        override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+        override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+        override fun afterTextChanged(editable: Editable?) {
+            val validationState = editable?.toString().validationState()
+            // Enable button if text is valid
+            _dialog?.getButton(Dialog.BUTTON_POSITIVE)?.isEnabled = (validationState == VALID)
+            // Show error if text invalid, hide error if text valid
+            editNumber.error = when (editable?.toString().validationState()) {
+                VALID -> null
+                TOO_LOW -> getString(R.string.error_min_card_for_review_ahead)
+                TOO_HIGH -> resources.getQuantityString(
+                        R.plurals.error_max_card_for_review_ahead, maxCardCount, maxCardCount)
+            }
+        }
+    }
+
+    private fun String?.validationState(): CountValidationState {
+        return this?.toIntOrNull()?.let {
+            when {
+                it < 1 -> TOO_LOW
+                it > maxCardCount -> TOO_HIGH
+                else -> VALID
+            }
+        } ?: TOO_LOW
+    }
+
+    private enum class CountValidationState { VALID, TOO_HIGH, TOO_LOW }
+}

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/review/ReviewViewModel.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/review/ReviewViewModel.kt
@@ -35,7 +35,6 @@ class ReviewViewModel @JvmOverloads constructor(
 
 
     private val cardUseCases: CardUseCases by inject()
-    //private val viewModelLibraryBooklet = DelegateLibraryBooklet(bookletId)
 
 
     // Current card used to make reviewCard on display

--- a/app/src/main/res/layout/dialog_review_ahead.xml
+++ b/app/src/main/res/layout/dialog_review_ahead.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:gravity="center_vertical"
+    android:padding="@dimen/dialog_fragment_margin"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="@dimen/dialog_fragment_margin"
+        android:text="@string/message_dialog_review_ahead"/>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/hint_card_number_for_review">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_number_card_to_review_ahead"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:singleLine="true"
+            android:inputType="number"
+            android:imeOptions="actionDone"/>
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/menu/menu_booklet.xml
+++ b/app/src/main/res/menu/menu_booklet.xml
@@ -10,14 +10,20 @@
         app:showAsAction="ifRoom" />
 
     <item
-        android:id="@+id/menu_action_rename_booklet"
+        android:id="@+id/menu_action_review_ahead"
         android:orderInCategory="2"
+        android:title="@string/menu_action_review_ahead"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/menu_action_rename_booklet"
+        android:orderInCategory="3"
         android:title="@string/menu_action_rename_booklet"
         app:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/menu_action_delete"
-        android:orderInCategory="3"
+        android:orderInCategory="4"
         android:title="@string/menu_action_delete"
         app:showAsAction="ifRoom" />
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,7 +2,7 @@
 
     <dimen name="fab_margin">16dp</dimen>
 
-    <dimen name="dialog_fragment_margin">20dp</dimen>
+    <dimen name="dialog_fragment_margin">24dp</dimen>
     <dimen name="large_margin">16dp</dimen>
     <dimen name="large_margin_inside_recycled_view">12dp</dimen>
     <dimen name="medium_margin">8dp</dimen>

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <plurals name="cards_to_review">
-        <item quantity="one">"%d card to review"</item>
-        <item quantity="other">"%d cards to review"</item>
+        <item quantity="one">"%d card to review today"</item>
+        <item quantity="other">"%d cards to review today"</item>
+    </plurals>
+    <plurals name="error_max_card_for_review_ahead">
+        <item quantity="one">"Maximum allowed: %d card"</item>
+        <item quantity="other">"Maximum allowed: %d cards"</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values/strings_booklet.xml
+++ b/app/src/main/res/values/strings_booklet.xml
@@ -5,6 +5,16 @@
     <string name="confirm_new_booklet">Add</string>
     <string name="confirm_rename_booklet">Rename</string>
 
+    <string name="title_dialog_review_ahead">Review cards ahead</string>
+    <string name="message_dialog_review_ahead">CAUTION: Reviewing too many cards on the same day might not be beneficial.
+        If you still want to review more cards now, select the number of additional cards to review now:</string>
+    <string name="hint_card_number_for_review">Number of cards to review now</string>
+    <string name="confirm_review_card">Review</string>
+    <string name="error_max_card_for_review_ahead">"Maximum allowed: %d"</string>
+    <string name="error_min_card_for_review_ahead">"Minimum: 1 card"</string>
+    <string name="completed_for_today_booklet_for_review_message">"No card to review"</string>
+    <string name="completed_for_today_booklet_for_review_action">"Review ahead"</string>
+
     <string name="empty_booklet_list">"You don't have any booklets to review yet. Try adding one with the bottom left button"</string>
     <string name="empty_booklet_for_review_message">"No card to review"</string>
     <string name="empty_booklet_for_review_action">"Add"</string>
@@ -12,5 +22,6 @@
     <string name="menu_action_show_about">About</string>
     <string name="menu_action_manage_cards">Manage cards</string>
     <string name="menu_action_rename_booklet">Rename this booklet</string>
+    <string name="menu_action_review_ahead">Review ahead</string>
     <string name="menu_action_delete">Delete this booklet</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/core/src/main/java/com/faust/m/core/data/CardDataSource.kt
+++ b/core/src/main/java/com/faust/m/core/data/CardDataSource.kt
@@ -20,5 +20,7 @@ interface CardDataSource {
 
     fun countCardsForBooklets(bookletIds: List<Long>): Map<Long, Int> // booklet_id -> count
 
+    fun resetForReview(count: Int, bookletId: Long)
+
     fun deleteCard(card: Card): Int
 }

--- a/core/src/main/java/com/faust/m/core/data/CardRepository.kt
+++ b/core/src/main/java/com/faust/m/core/data/CardRepository.kt
@@ -16,6 +16,8 @@ class CardRepository(private val dataSource: CardDataSource) {
     fun getAllCardShellsForBooklets(bookletIds: List<Long>): LongSparseArray<MutableList<Card>> =
         dataSource.getAllCardShellsForBooklets(bookletIds)
 
+    fun resetForReview(count: Int, bookletId: Long) = dataSource.resetForReview(count, bookletId)
+
     fun countCardForBooklets(bookletIds: List<Long>): Map<Long, Int> =
         dataSource.countCardsForBooklets(bookletIds)
 

--- a/core/src/main/java/com/faust/m/core/domain/Card.kt
+++ b/core/src/main/java/com/faust/m/core/domain/Card.kt
@@ -55,7 +55,7 @@ data class Card (
      * To be eligible for review, a card must have a rating inferior to 5
      * (5 means the card is learned), and it must have not have been reviewed today
      */
-    internal fun needReview(): Boolean {
+    fun needReview(): Boolean {
         return ratingLevel() != FAMILIAR && needReviewToday()
     }
 

--- a/core/src/main/java/com/faust/m/core/usecase/booklet/ResetForReview.kt
+++ b/core/src/main/java/com/faust/m/core/usecase/booklet/ResetForReview.kt
@@ -1,0 +1,9 @@
+package com.faust.m.core.usecase.booklet
+
+import com.faust.m.core.data.CardRepository
+
+class ResetForReview(private val cardRepository: CardRepository) {
+
+    operator fun invoke(count: Int, bookletId: Long) =
+        cardRepository.resetForReview(count, bookletId)
+}


### PR DESCRIPTION
- Add menu to review cards ahead in library
- Modify snackbar in library when user want to review a booklet with all
cards already reviewed
- Present a dialog to user asking how many cards should be reviewed
ahead
- Add useCase to reset X cards for review in a booklet
- Automatically launch activity for review of cards that we just reset