### PR TITLE
REFACTOR Use room liveData

### DIFF
--- a/app/src/androidTest/java/com/faust/m/flashcardm/framework/db/room/CardRoomDataSourceTest.kt
+++ b/app/src/androidTest/java/com/faust/m/flashcardm/framework/db/room/CardRoomDataSourceTest.kt
@@ -4,6 +4,7 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.faust.m.flashcardm.core.domain.Card
 import com.faust.m.flashcardm.core.domain.CardContent
 import com.faust.m.flashcardm.core.domain.CardContentType.FRONT
+import com.faust.m.flashcardm.core.domain.toRoster
 import com.faust.m.flashcardm.framework.db.room.definition.FlashRoomDatabase
 import com.faust.m.flashcardm.framework.db.room.model.*
 import io.mockk.every
@@ -18,9 +19,9 @@ import java.util.*
 class CardRoomDataSourceTest: BaseDaoTest() {
 
     private val bookletEntity = BookletEntity("My Second Booklet", 25)
-    private val cardContent = CardContent("content", FRONT)
+    private val cardContent = CardContent("content", FRONT, cardId = 2, id = 3)
     private val card =
-        Card(rating = 0, lastSeen = Date(), bookletId = bookletEntity.id).add(cardContent)
+        Card(rating = 0, lastSeen = Date(), bookletId = bookletEntity.id, id = 2).add(cardContent)
 
     private lateinit var _database: FlashRoomDatabase
     private lateinit var cardRoomDataSource: CardRoomDataSource
@@ -50,72 +51,19 @@ class CardRoomDataSourceTest: BaseDaoTest() {
                 assertThat(it.bookletId)
                     .`as`("BookletId from card in cursor")
                     .isEqualTo(25)
-                assertThat(it.content[FRONT]?.size)
-                    .`as`("List of recto content from card in database")
-                    .isEqualTo(1)
-                assertThat(it.content[FRONT]?.first()?.value)
-                    .`as`("First cardContent in card from database")
-                    .isEqualTo("content")
+                assertThat(it.roster).containsExactly(
+                    CardContent(
+                        value = "content",
+                        type = FRONT,
+                        cardId = 2,
+                        id = 3)
+                )
             }
         }
     }
 
     private fun givenABookletInDatabase() {
         bookletDao.add(bookletEntity)
-    }
-
-    @Test
-    fun testCountCardForBookletsReturnCount() {
-        given2BookletsAnd3CardsInDatabase()
-
-        // I can retrieve the card count by booklet id
-        assertThat(cardRoomDataSource.countCardsForBooklets(listOf(10)))
-            .isEqualTo(HashMap<Long, Int>().also{ it[10] = 1 })
-        assertThat(cardRoomDataSource.countCardsForBooklets(listOf(10, 25)))
-            .isEqualTo(HashMap<Long, Int>().also {
-                it[10] = 1
-                it[25] = 2
-            })
-    }
-
-    private fun given2BookletsAnd3CardsInDatabase() {
-        bookletDao.add(BookletEntity("My first booklet", 10))
-        bookletDao.add(BookletEntity("My Second Booklet", 25))
-        cardDao.add(CardEntity(5, Date(20), Date(20),10, 1))
-        cardDao.add(CardEntity(5, Date(1000), Date(1000),25, 3))
-        cardDao.add(CardEntity(5, Date(30000), Date(30000),25, 5))
-    }
-
-    @Test
-    fun getAllCardShellsForBookletIdsShouldReturnCardShellForAllBooklets() {
-        given2BookletsAnd3CardsInDatabase()
-
-        // When I get all cardShells for 2 different booklets
-        cardRoomDataSource.getAllCardShellsForBooklets(listOf(10, 25)).let {
-            // The map contains a list of cardShell for each booklet
-            assertThat(it[10])
-                .`as`("CardShells for bookletId = 10")
-                .containsExactly(
-                    Card(5, Date(20), bookletId = 10, id = 1)
-                )
-            assertThat(it[25])
-                .`as`("CardShells for bookletId = 25")
-                .containsExactlyInAnyOrder(
-                    Card(5, Date(1000), bookletId = 25, id = 3),
-                    Card(5, Date(30000), bookletId = 25, id = 5)
-                )
-        }
-    }
-
-    @Test
-    fun getAllCardShellsForBookletIdsShouldNoEntryIfCardListIsEmpty() {
-        given2BookletsAnd3CardsInDatabase()
-
-        // When I get all cardShells for a non existing booklet
-        cardRoomDataSource.getAllCardShellsForBooklets(listOf(20)).let {
-            // There is no entry in the map for non existing booklet
-            assertThat(it[20]).isNull()
-        }
     }
 
     @Test
@@ -159,11 +107,13 @@ class CardRoomDataSourceTest: BaseDaoTest() {
     }
 
     private fun whenIUpdateCardContent() {
-        val cardToUpdate: Card = Card(createdAt = Date(3000), bookletId = 25, id = 1).apply {
-            content[FRONT] = mutableListOf(
+        val cardToUpdate = Card(
+            createdAt = Date(3000),
+            roster = mutableListOf(
                 CardContent(value = "new_value", type = FRONT, cardId = 1, id = 3)
-            )
-        }
+            ).toRoster(),
+            bookletId = 25, id = 1
+        )
         cardRoomDataSource.updateCardContent(cardToUpdate)
     }
 
@@ -207,13 +157,12 @@ class CardRoomDataSourceTest: BaseDaoTest() {
             rating = 2,
             lastSeen = Date(30),
             createdAt = Date(500),
+            roster = mutableListOf(
+                CardContent(value = "val", type = FRONT, cardId = 1, id = 0)
+            ).toRoster(),
             bookletId = 2,
             id = 3
-        ).apply {
-            content[FRONT] = mutableListOf(
-                CardContent(value = "val", type = FRONT, cardId = 1, id = 0)
-            )
-        }
+        )
         try {
             cardRoomDataSourceException.add(card)
         } catch (e: java.lang.RuntimeException) {
@@ -237,19 +186,18 @@ class CardRoomDataSourceTest: BaseDaoTest() {
             rating = 5,
             createdAt = Date(20),
             lastSeen = Date(30),
-            bookletId = 25,
-            id = 1
-        ).apply {
-            content[FRONT] = mutableListOf(CardContent(
+            roster = mutableListOf(CardContent(
                 value = "old_value",
                 type = FRONT,
                 cardId = 1,
                 id = 3
-            ))
-        }
+            )).toRoster(),
+            bookletId = 25,
+            id = 1
+        )
 
         cardRoomDataSource.add(cardWithContent).let {
-            assertThat(it.content[FRONT]).containsExactly(CardContent(
+            assertThat(it.roster).containsExactly(CardContent(
                     value = "old_value",
                     type = FRONT,
                     cardId = 1,
@@ -267,19 +215,18 @@ class CardRoomDataSourceTest: BaseDaoTest() {
             rating = 5,
             createdAt = Date(20),
             lastSeen = Date(30),
-            bookletId = 25,
-            id = 1
-        ).apply {
-            content[FRONT] = mutableListOf(CardContent(
+            roster = mutableListOf(CardContent(
                 value = "old_value",
                 type = FRONT,
                 cardId = 0, // Card id is not set to the correct card yet
                 id = 3
-            ))
-        }
+            )).toRoster(),
+            bookletId = 25,
+            id = 1
+        )
 
         cardRoomDataSource.add(cardWithContent).let {
-            assertThat(it.content[FRONT]).containsExactly(CardContent(
+            assertThat(it.roster).containsExactly(CardContent(
                 value = "old_value",
                 type = FRONT,
                 cardId = 1,

--- a/app/src/main/java/com/faust/m/flashcardm/core/data/CardDataSource.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/core/data/CardDataSource.kt
@@ -1,7 +1,6 @@
 package com.faust.m.flashcardm.core.data
 
 import androidx.lifecycle.LiveData
-import com.faust.m.flashcardm.core.LongSparseArrayList
 import com.faust.m.flashcardm.core.domain.Card
 import com.faust.m.flashcardm.core.domain.Deck
 
@@ -18,13 +17,6 @@ interface CardDataSource {
     fun getLiveDeckForBooklet(bookletId: Long): LiveData<Deck>
 
     fun getAllCardsForBooklet(bookletId: Long): List<Card>
-
-    /**
-     * Return a sparseArray bookletId -> list<Card>
-     */
-    fun getAllCardShellsForBooklets(bookletIds: List<Long>): LongSparseArrayList<Card>
-
-    fun countCardsForBooklets(bookletIds: List<Long>): Map<Long, Int> // booklet_id -> count
 
     fun resetForReview(count: Int, bookletId: Long): Int
 

--- a/app/src/main/java/com/faust/m/flashcardm/core/data/CardRepository.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/core/data/CardRepository.kt
@@ -1,6 +1,5 @@
 package com.faust.m.flashcardm.core.data
 
-import androidx.collection.LongSparseArray
 import androidx.lifecycle.LiveData
 import com.faust.m.flashcardm.core.domain.Card
 import com.faust.m.flashcardm.core.domain.Deck
@@ -20,13 +19,7 @@ class CardRepository(private val dataSource: CardDataSource) {
 
     fun getAllCardsForBooklet(bookletId: Long) = dataSource.getAllCardsForBooklet(bookletId)
 
-    fun getAllCardShellsForBooklets(bookletIds: List<Long>): LongSparseArray<MutableList<Card>> =
-        dataSource.getAllCardShellsForBooklets(bookletIds)
-
     fun resetForReview(count: Int, bookletId: Long): Int = dataSource.resetForReview(count, bookletId)
-
-    fun countCardForBooklets(bookletIds: List<Long>): Map<Long, Int> =
-        dataSource.countCardsForBooklets(bookletIds)
 
     fun deleteCard(card: Card): Int = dataSource.deleteCard(card)
 }

--- a/app/src/test/java/com/faust/m/flashcardm/core/domain/CardTest.kt
+++ b/app/src/test/java/com/faust/m/flashcardm/core/domain/CardTest.kt
@@ -1,5 +1,7 @@
 package com.faust.m.flashcardm.core.domain
 
+import com.faust.m.flashcardm.core.domain.CardContentType.BACK
+import com.faust.m.flashcardm.core.domain.CardContentType.FRONT
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.util.*
@@ -168,6 +170,38 @@ class CardTest {
         deck.countToReviewCard().let { result ->
             assertThat(result).isEqualTo(1)
         }
+    }
+
+    @Test
+    fun testCardEqualsShouldBeTrueWhenRosterContainSameCardContent() {
+        val card = Card(
+            rating = 2,
+            lastSeen = Date(30),
+            createdAt = Date(20),
+            roster = mutableListOf(CardContent(
+                value = "to learn",
+                type = FRONT,
+                cardId = 35,
+                id = 22
+            )).toRoster(),
+            bookletId = 14,
+            id = 35
+        )
+        val identicalCard = Card(
+            rating = 2,
+            lastSeen = Date(30),
+            createdAt = Date(20),
+            roster = mutableListOf(CardContent(
+                value = "to learn",
+                type = FRONT,
+                cardId = 35,
+                id = 22
+            )).toRoster(),
+            bookletId = 14,
+            id = 35
+        )
+
+        assertThat(card).isEqualTo(identicalCard)
     }
 
 


### PR DESCRIPTION
- Create class Roster = MutableList<CardContent>
- Replace enumMap in Card by Roster: code looks cleaner, performance
impact is low because there should never be more than 10 cardContent so
search in list are going to be quick
- Remove unused method `getAllCardShellForBooklet` and
`countCardForBooklet`

Links #13 