### PR TITLE
REFACTOR BookletViewModel and ReviewViewModel now use liveData from room

### DIFF
--- a/app/src/main/java/com/faust/m/flashcardm/core/data/CardDataSource.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/core/data/CardDataSource.kt
@@ -14,17 +14,11 @@ interface CardDataSource {
 
     fun getLiveDeck(): LiveData<Deck>
 
-    fun getLiveDeckForBooklet(bookletId: Long): LiveData<Deck>
-
     fun getLiveDeckForBooklet(bookletId: Long,
                               attachCardContent: Boolean = false,
                               filterToReviewCard: Boolean = false): LiveData<Deck>
 
-    fun getAllCardsForBooklet(bookletId: Long): List<Card>
-
     fun resetForReview(count: Int, bookletId: Long): Int
-
-    fun deleteCard(card: Card): Int
 
     fun deleteCards(cards: List<Card>): Int
 }

--- a/app/src/main/java/com/faust/m/flashcardm/core/data/CardRepository.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/core/data/CardRepository.kt
@@ -14,19 +14,12 @@ class CardRepository(private val dataSource: CardDataSource) {
 
     fun getLiveDeck(): LiveData<Deck> = dataSource.getLiveDeck()
 
-    fun getLiveDeckForBooklet(bookletId: Long): LiveData<Deck> =
-        dataSource.getLiveDeckForBooklet(bookletId)
-
-    fun getAllCardsForBooklet(bookletId: Long) = dataSource.getAllCardsForBooklet(bookletId)
-
     fun getLiveDeckForBooklet(bookletId: Long,
                               attachCardContent: Boolean = false,
                               filterToReviewCard: Boolean = false): LiveData<Deck> =
         dataSource.getLiveDeckForBooklet(bookletId, attachCardContent, filterToReviewCard)
 
     fun resetForReview(count: Int, bookletId: Long): Int = dataSource.resetForReview(count, bookletId)
-
-    fun deleteCard(card: Card): Int = dataSource.deleteCard(card)
 
     fun deleteCards(cards: List<Card>): Int = dataSource.deleteCards(cards)
 }

--- a/app/src/main/java/com/faust/m/flashcardm/core/usecase/CardUseCases.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/core/usecase/CardUseCases.kt
@@ -1,18 +1,20 @@
 package com.faust.m.flashcardm.core.usecase
 
+import androidx.lifecycle.LiveData
 import com.faust.m.flashcardm.core.data.CardRepository
 import com.faust.m.flashcardm.core.domain.Card
+import com.faust.m.flashcardm.core.domain.Deck
 
 class CardUseCases private constructor(val addCard: AddCard,
                                        val deleteCards: DeleteCards,
-                                       val getCardsForBooklet: GetCardsForBooklet,
+                                       val getLiveDeck: GetLiveDeck,
                                        val updateCard: UpdateCard,
                                        val updateCardContent: UpdateCardContent) {
 
     constructor(cardRepository: CardRepository): this(
         AddCard(cardRepository),
         DeleteCards(cardRepository),
-        GetCardsForBooklet(cardRepository),
+        GetLiveDeck(cardRepository),
         UpdateCard(cardRepository),
         UpdateCardContent(cardRepository)
     )
@@ -25,18 +27,15 @@ class AddCard(private val cardRepository: CardRepository) {
 
 class DeleteCards(private val cardRepository: CardRepository) {
 
-    operator fun invoke(cards :List<Card>): Int = cardRepository.deleteCards(cards)
+    operator fun invoke(cards: List<Card>): Int = cardRepository.deleteCards(cards)
 }
 
-class GetCardsForBooklet(private val cardRepository: CardRepository) {
+class GetLiveDeck(private val cardRepository: CardRepository) {
 
-    operator fun invoke(bookletId: Long, filterReviewCard: Boolean = false): List<Card> =
-        cardRepository.getAllCardsForBooklet(bookletId).run {
-            when {
-                filterReviewCard -> filter(Card::needReview)
-                else -> this
-            }
-        }
+    operator fun invoke(bookletId: Long,
+                        attachCardContent: Boolean = false,
+                        filterToReviewCard: Boolean = false): LiveData<Deck> =
+        cardRepository.getLiveDeckForBooklet(bookletId, attachCardContent, filterToReviewCard)
 }
 
 class UpdateCard(private val cardRepository: CardRepository) {

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/PresentationExtensions.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/PresentationExtensions.kt
@@ -104,6 +104,25 @@ open class MutableLiveList<T>: MutableLiveData<MutableList<T>>() {
     }
 }
 
+/**
+ * MutableLiveSet is a mutable set that can be used as a liveData. Observers will be called
+ * only when there is an addition to the set.
+ * (Probably could be refactored to also trigger when an object is removed from the set, I'll see
+ * to it when I actually need that functionality)
+ */
+class MutableLiveSet<T> private constructor(private val inner :HashSet<T>) :
+    MutableLiveData<MutableSet<T>>(HashSet()), MutableSet<T> by inner {
+
+    constructor(): this(HashSet())
+
+    override fun add(element: T): Boolean {
+        val result = inner.add(element)
+        if (result)
+            value = value
+        return result
+    }
+}
+
 class MutableLiveEvent<T>: MutableLiveData<Event<T>>() {
 
     fun postEvent(event: T) {

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/booklet/BookletActivity.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/booklet/BookletActivity.kt
@@ -28,7 +28,6 @@ class BookletActivity: AppCompatActivity(), LiveDataObserver {
 
         viewModel = getKoin().get<BookletViewModelFactory>().createViewModelFrom(this)
         viewModel.cardEditionState.observeData(this, ::onCardEditionStateChanged)
-        viewModel.loadData()
     }
 
     private fun onCardEditionStateChanged(cardEditionState: CardEditionState) =

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/fragment_edit_card/ViewModelEditCard.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/fragment_edit_card/ViewModelEditCard.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.faust.m.flashcardm.core.domain.Card
 import com.faust.m.flashcardm.core.usecase.CardUseCases
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.jetbrains.anko.AnkoLogger
@@ -37,11 +35,6 @@ interface ViewModelEditCard {
     val cardToEdit: LiveData<Card?>
     val cardEditionState: LiveData<CardEditionState>
 
-    var onCardCreated: ((newCard: Card) -> Unit)?
-    var onCardEdited: ((editedCard: Card) -> Unit)?
-
-    fun parentScope(): CoroutineScope?
-
     fun addCard(front: String, back: String)
     fun editCard(front: String, back: String)
     fun startCardAddition()
@@ -64,12 +57,7 @@ class DelegateEditCard(private val bookletId: Long): ViewModelEditCard, KoinComp
     private val _cardToEdit: MutableLiveData<Card?> = MutableLiveData()
     override val cardToEdit: LiveData<Card?> = _cardToEdit
 
-    override var onCardCreated: ((newCard: Card) -> Unit)? = null
-    override var onCardEdited: ((editedCard: Card) -> Unit)? = null
-
-
-    override fun parentScope(): CoroutineScope? = null
-
+    
     override fun addCard(front: String, back: String) {
         _cardToEdit.value?.let {
             it.addFrontAsText(front)
@@ -78,7 +66,6 @@ class DelegateEditCard(private val bookletId: Long): ViewModelEditCard, KoinComp
                 cardUseCases.addCard(it).also { newCard ->
                     verbose { "Created a new card: $newCard" }
                     _cardToEdit.postValue(Card(bookletId = bookletId))
-                    onCardCreated?.invoke(newCard)
                 }
             }
         }
@@ -91,7 +78,6 @@ class DelegateEditCard(private val bookletId: Long): ViewModelEditCard, KoinComp
             GlobalScope.launch {
                 cardUseCases.updateCardContent(cardToUpdate).also { updatedCard ->
                     verbose { "Updated a card: $updatedCard" }
-                    onCardEdited?.invoke(updatedCard)
                 }
             }
         }

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/review/ReviewActivity.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/review/ReviewActivity.kt
@@ -30,7 +30,6 @@ class ReviewActivity: AppCompatActivity(), LiveDataObserver {
             getKoin().get<BookletViewModelFactory>().createViewModelFrom(this)
         viewModel.reviewCard.observeData(this, ::onCurrentCardChanged)
         viewModel.cardEditionState.observeData(this, ::onCardEditionStateChanged)
-        viewModel.loadData()
     }
 
     private fun onCurrentCardChanged(reviewCard: ReviewCard) {

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/review/ReviewViewModel.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/review/ReviewViewModel.kt
@@ -2,19 +2,19 @@ package com.faust.m.flashcardm.presentation.review
 
 import androidx.lifecycle.*
 import com.faust.m.flashcardm.core.domain.Card
+import com.faust.m.flashcardm.core.domain.Deck
 import com.faust.m.flashcardm.core.usecase.BookletUseCases
 import com.faust.m.flashcardm.core.usecase.CardUseCases
+import com.faust.m.flashcardm.presentation.MutableLiveSet
 import com.faust.m.flashcardm.presentation.fragment_edit_card.DelegateEditCard
 import com.faust.m.flashcardm.presentation.fragment_edit_card.ViewModelEditCard
 import com.faust.m.flashcardm.presentation.library.BookletBannerData
 import com.faust.m.flashcardm.presentation.library.toBookletBanner
 import com.faust.m.flashcardm.presentation.review.ReviewCard.State.ASKING
 import com.faust.m.flashcardm.presentation.review.ReviewCard.State.RATING
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.jetbrains.anko.AnkoLogger
-import org.jetbrains.anko.warn
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 import java.util.*
@@ -26,10 +26,6 @@ class ReviewViewModel @JvmOverloads constructor(
     KoinComponent,
     ViewModelEditCard by delegateEditCard,
     AnkoLogger {
-
-    // Initialize the delegate for card edition with a listener onCardEdited
-    init { delegateEditCard.onCardEdited = ::onCardEdited }
-
 
     private val bookletUseCases: BookletUseCases by inject()
     private val cardUseCases: CardUseCases by inject()
@@ -45,92 +41,93 @@ class ReviewViewModel @JvmOverloads constructor(
         }
 
     // Current card used to make reviewCard on display
-    private val _currentCard: MutableLiveData<Card?> = MutableLiveData()
-    // Current reviewCard on display
-    private val _reviewCard: MutableLiveData<ReviewCard> = MutableLiveData()
-    val reviewCard: LiveData<ReviewCard> = _reviewCard
+    private var _currentCard: Card? = null
 
-    // Queue of cards (only cards to review) for the booklet on review
-    private var _cardQueue = LinkedList<Card>()
+    // Current deck of cards to review for booklet
+    private val _liveDeck =
+        cardUseCases.getLiveDeck(bookletId, attachCardContent = true, filterToReviewCard = true)
+    // List of id of card that have been marked as reviewLater
+    private val _liveCardsToRepeat: MutableLiveSet<Long> = MutableLiveSet()
 
-
-    override fun parentScope(): CoroutineScope? = viewModelScope
-
-    fun loadData() {
-        viewModelScope.launch(Dispatchers.IO) {
-            cardUseCases
-                .getCardsForBooklet(bookletId, filterReviewCard = true)
-                .forEach { _cardQueue.add(it) }
-            postCardUpdate()
-        }
+    // reviewCard: Receive data from _liveDeck for each updates on the deck of cards to review
+    // and event from _cardsToRepeat when a new card has been marked for repeat later
+    val reviewCard: MediatorLiveData<ReviewCard> = MediatorLiveData<ReviewCard>().apply {
+        addSource(_liveDeck) { postReviewCards() }
+        addSource(_liveCardsToRepeat) { postReviewCards() }
     }
 
 
-    fun flipCurrentCard() {
-        postCardUpdate()
-    }
+    fun flipCurrentCard() =
+        reviewCard.value?.copy(state = RATING, animate = true).let { reviewCard.postValue(it) }
 
     fun validateCurrentCard() {
-        _currentCard.value?.let {
-            val cardToUpdate = it.copy(rating = it.rating + 1, lastSeen = Date())
-            viewModelScope.launch(Dispatchers.IO) {
-                cardUseCases.updateCard(cardToUpdate).also { updatedCard: Card ->
-                    warn { "Card updated $updatedCard" }
-                    postCardUpdate()
-                }
+        viewModelScope.launch(Dispatchers.IO) {
+            _currentCard?.let { card ->
+                card.copy(rating = card.rating + 1, lastSeen = Date())
+                    .let{ cardUseCases.updateCard(it) }
             }
         }
     }
 
     fun repeatCurrentCard() {
-        _currentCard.value?.let { _cardQueue.add(it) }
-        postCardUpdate()
+        _currentCard?.let { card -> _liveCardsToRepeat.add(card.id) }
     }
 
-    fun startEditCard() =
-        delegateEditCard.startCardEdition(_currentCard.value)
-
-
-    private fun postCardUpdate() {
-        val card =
-            if (_reviewCard.value.isFinished()) {
-                when {
-                    _cardQueue.isNotEmpty() -> _cardQueue.remove()
-                    else -> null
-                }
-            } else {
-                _currentCard.value
-            }
-        _currentCard.postValue(card)
-
-        val tReviewCard =
-            if (null != card) reviewCardFrom(card, _reviewCard.value)
-            else ReviewCard.EMPTY
-        _reviewCard.postValue(tReviewCard)
+    fun startEditCard() {
+        delegateEditCard.startCardEdition(_currentCard)
     }
 
-    private fun reviewCardFrom(card: Card, previousReviewCard: ReviewCard?): ReviewCard =
-        if (previousReviewCard.isFinished()) {
-            ReviewCard(card, ASKING, true)
-        }
-        else {
-            previousReviewCard!!.copy(state = RATING, animate = true)
-        }
 
-    private fun onCardEdited(cardEdited: Card) {
-        // Updating currentCard will trigger an update on _reviewCard
-        // So I reset _reviewCard to a value which will lead to a good updated value
-        viewModelScope.launch(Dispatchers.IO) {
-            _currentCard.postValue(cardEdited)
-            _reviewCard.value?.let {
-                _reviewCard.postValue(it.copy(
-                    front = cardEdited.frontAsTextOrNull() ?: "",
-                    back = cardEdited.backAsTextOrNull() ?: "",
+    /*
+     * Cranky mechanic of choosing which card to review in the deck and
+     * how to update reviewCard value. I intend to change it once I add a `nextReviewDate` on Card
+     */
+    private fun postReviewCards() {
+        val deck = _liveDeck.value ?: return
+        val nextCardInLine = nextCardFromDeck(deck)
+        when (nextCardInLine?.id) {
+            _currentCard?.id -> updateReviewCardValueFromCurrentCard()
+            else -> updateReviewCardValueFrom(nextCardInLine)
+        }
+    }
+
+    private fun nextCardFromDeck(deck: Deck): Card? {
+        // If all cards left have been marked as "to repeat", then remove all card from cardsToRepeat
+        // It will enable card to be reviewed once more during this "review session"
+        if (deck.size == _liveCardsToRepeat.size) {
+            _liveCardsToRepeat.clear()
+        }
+        return deck.firstOrNull { c -> !_liveCardsToRepeat.contains(c.id) }
+    }
+
+    private fun updateReviewCardValueFromCurrentCard() = reviewCard.value?.let { reviewCardValue ->
+        if (reviewCardValue.needUpdateFrom(_currentCard)) {
+            reviewCardValue
+                .copy(
+                    front = _currentCard?.frontAsTextOrNull() ?: "",
+                    back = _currentCard?.backAsTextOrNull() ?: "",
                     animate = false
-                ))
-            }
+                )
+                .let { reviewCard.postValue(it) }
         }
     }
+
+    private fun ReviewCard?.needUpdateFrom(card: Card?): Boolean {
+        return this != null && card != null &&
+                (front != card.frontAsTextOrNull() || back != card.backAsTextOrNull())
+    }
+
+    private fun updateReviewCardValueFrom(card: Card?) {
+        _currentCard = card
+        reviewCardFrom(card, reviewCard.value).let { reviewCard.postValue(it)  }
+    }
+
+    private fun reviewCardFrom(card: Card?, previousReviewCard: ReviewCard?): ReviewCard =
+        when {
+            card == null -> ReviewCard.EMPTY
+            previousReviewCard.isFinished() -> ReviewCard(card, ASKING, true)
+            else -> previousReviewCard!!.copy(state = RATING, animate = true)
+        }
 }
 
 /**


### PR DESCRIPTION
- Clean BookletUseCaseTest: use the new OntTimeObserverRule
- Add MutableLiveSet which trigger observer when adding object to the
set
- Refactor BookletViewModel to use liveData from room for cards in deck
- Refactor ReviewViewModel to use liveData from room for cards in deck