### PR TITLE
REFACTOR BookletViewModel and ReviewViewModel now use liveData from room

### DIFF
--- a/app/src/androidTest/java/com/faust/m/flashcardm/framework/db/room/CardRoomDataSourceTest.kt
+++ b/app/src/androidTest/java/com/faust/m/flashcardm/framework/db/room/CardRoomDataSourceTest.kt
@@ -10,7 +10,6 @@ import com.faust.m.flashcardm.framework.db.room.model.*
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.*
@@ -19,9 +18,6 @@ import java.util.*
 class CardRoomDataSourceTest: BaseDaoTest() {
 
     private val bookletEntity = BookletEntity("My Second Booklet", 25)
-    private val cardContent = CardContent("content", FRONT, cardId = 2, id = 3)
-    private val card =
-        Card(rating = 0, lastSeen = Date(), bookletId = bookletEntity.id, id = 2).add(cardContent)
 
     private lateinit var _database: FlashRoomDatabase
     private lateinit var cardRoomDataSource: CardRoomDataSource
@@ -35,35 +31,6 @@ class CardRoomDataSourceTest: BaseDaoTest() {
         bookletDao = bookletDao()
         cardDao = cardDao()
         cardContentDao = cardContentDao()
-    }
-
-    @Test
-    fun testGetCardWithCardContentShouldReturnCompleteCard() {
-        givenABookletInDatabase()
-
-        // When I insert a card with cardContent
-        cardRoomDataSource.add(card)
-
-        // I can retrieve the card with the same attributes
-        cardRoomDataSource.getAllCardsForBooklet(card.bookletId).apply {
-            assertThat(size).`as`("Number of cards in cursor").isEqualTo(1)
-            first().also {
-                assertThat(it.bookletId)
-                    .`as`("BookletId from card in cursor")
-                    .isEqualTo(25)
-                assertThat(it.roster).containsExactly(
-                    CardContent(
-                        value = "content",
-                        type = FRONT,
-                        cardId = 2,
-                        id = 3)
-                )
-            }
-        }
-    }
-
-    private fun givenABookletInDatabase() {
-        bookletDao.add(bookletEntity)
     }
 
     @Test
@@ -233,119 +200,5 @@ class CardRoomDataSourceTest: BaseDaoTest() {
                 id = 3
             ))
         }
-    }
-
-    @Test
-    fun testResetCardForReviewShouldMakeCardsAvailableForReview() {
-        givenABookletAnd4CardsNotForReviewWithDifferentRating()
-
-        // When I reset 2 cards for review
-        cardRoomDataSource.resetForReview(2, 25)
-
-        // There should be 2 card for review
-        cardRoomDataSource.getAllCardsForBooklet(25).filter(Card::needReview).run {
-            assertThat(size).`as`("There should be 2 card for review").isEqualTo(2)
-        }
-    }
-
-    private fun givenABookletAnd4CardsNotForReviewWithDifferentRating() {
-        bookletDao.add(bookletEntity)
-        cardDao.add(CardEntity(4, Date(), Date(20),25, 1))
-        cardDao.add(CardEntity(2, Date(), Date(20),25, 2))
-        cardDao.add(CardEntity(1, Date(), Date(20),25, 3))
-        cardDao.add(CardEntity(3, Date(), Date(20),25, 4))
-
-        cardRoomDataSource
-            .getAllCardsForBooklet(25)
-            .filter(Card::needReview)
-            .run {
-                assumeTrue("There should be no card to review yet", size == 0)
-            }
-    }
-
-    @Test
-    fun testResetCardForReviewShouldResetLowRatingCardFirst() {
-        givenABookletAnd4CardsNotForReviewWithDifferentRating()
-
-        // When I reset cards for review
-        cardRoomDataSource.resetForReview(2, 25)
-
-        // The cards for review should be the one with lowest rating
-        cardRoomDataSource
-            .getAllCardsForBooklet(25)
-            .filter(Card::needReview)
-            .run {
-                assertThat(this.map { it.rating }).containsExactlyInAnyOrder(1, 2)
-            }
-    }
-
-    @Test
-    fun testResetCardForReviewWhenNotEnoughCardShouldResetAsManyCardsAsPossible() {
-        givenABookletAnd4CardsNotForReviewWithDifferentRating()
-
-        // When I try to reset more card than possible
-        cardRoomDataSource.resetForReview(5, 25)
-
-        // All cards should be reset
-        cardRoomDataSource
-            .getAllCardsForBooklet(25)
-            .filter(Card::needReview)
-            .run {
-                assertThat(size).`as`("All card should need review").isEqualTo(4)
-            }
-    }
-
-    @Test
-    fun testResetCardForReviewShouldResetRatingUnder5IfNecessaryToMakeEnoughCardsForReview() {
-        // Given a booklet with 2 card (one with rating 5, so unelectable for review normally)
-        bookletDao.add(bookletEntity)
-        cardDao.add(CardEntity(5, Date(), Date(20),25, 1))
-        cardDao.add(CardEntity(2, Date(), Date(20),25, 2))
-
-        cardRoomDataSource
-            .getAllCardsForBooklet(25)
-            .filter(Card::needReview)
-            .run {
-                assumeTrue("There should be no card to review yet", size == 0)
-            }
-
-        // When I try to reset 2 cards for review
-        cardRoomDataSource.resetForReview(2, 25)
-
-        // The card with rating 5 should have dropped to 4 (rating 2 should stay the same)
-        cardRoomDataSource
-            .getAllCardsForBooklet(25)
-            .filter(Card::needReview)
-            .run {
-                assertThat(this.map { it.rating }).containsExactlyInAnyOrder(2, 4)
-            }
-    }
-
-    @Test
-    fun testResetCardForReviewShouldResetOnlyCardThatAreNotForReviewNow() {
-        // Given a booklet with 3 cards (one already in review state)
-        bookletDao.add(bookletEntity)
-        cardDao.add(CardEntity(3, Date(30), Date(20),25, 1))
-        cardDao.add(CardEntity(4, Date(), Date(20),25, 2))
-        cardDao.add(CardEntity(4, Date(), Date(20),25, 3))
-
-        cardRoomDataSource
-            .getAllCardsForBooklet(25)
-            .filter(Card::needReview)
-            .run {
-                assumeTrue("There should be one card for review already", size == 1)
-            }
-
-        // When I try to reset 1 card for review
-        cardRoomDataSource.resetForReview(1, 25)
-
-        // There should be 2 cards for review now (the previous one,
-        // plus the one that was just changed)
-        cardRoomDataSource
-            .getAllCardsForBooklet(25)
-            .filter(Card::needReview)
-            .run {
-                assertThat(size).`as`("There should be 2 cards to review yet").isEqualTo(2)
-            }
     }
 }

--- a/app/src/main/java/com/faust/m/flashcardm/core/data/CardDataSource.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/core/data/CardDataSource.kt
@@ -14,17 +14,11 @@ interface CardDataSource {
 
     fun getLiveDeck(): LiveData<Deck>
 
-    fun getLiveDeckForBooklet(bookletId: Long): LiveData<Deck>
-
     fun getLiveDeckForBooklet(bookletId: Long,
                               attachCardContent: Boolean = false,
                               filterToReviewCard: Boolean = false): LiveData<Deck>
 
-    fun getAllCardsForBooklet(bookletId: Long): List<Card>
-
     fun resetForReview(count: Int, bookletId: Long): Int
-
-    fun deleteCard(card: Card): Int
 
     fun deleteCards(cards: List<Card>): Int
 }

--- a/app/src/main/java/com/faust/m/flashcardm/core/data/CardRepository.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/core/data/CardRepository.kt
@@ -14,19 +14,12 @@ class CardRepository(private val dataSource: CardDataSource) {
 
     fun getLiveDeck(): LiveData<Deck> = dataSource.getLiveDeck()
 
-    fun getLiveDeckForBooklet(bookletId: Long): LiveData<Deck> =
-        dataSource.getLiveDeckForBooklet(bookletId)
-
-    fun getAllCardsForBooklet(bookletId: Long) = dataSource.getAllCardsForBooklet(bookletId)
-
     fun getLiveDeckForBooklet(bookletId: Long,
                               attachCardContent: Boolean = false,
                               filterToReviewCard: Boolean = false): LiveData<Deck> =
         dataSource.getLiveDeckForBooklet(bookletId, attachCardContent, filterToReviewCard)
 
     fun resetForReview(count: Int, bookletId: Long): Int = dataSource.resetForReview(count, bookletId)
-
-    fun deleteCard(card: Card): Int = dataSource.deleteCard(card)
 
     fun deleteCards(cards: List<Card>): Int = dataSource.deleteCards(cards)
 }

--- a/app/src/main/java/com/faust/m/flashcardm/core/usecase/CardUseCases.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/core/usecase/CardUseCases.kt
@@ -1,18 +1,20 @@
 package com.faust.m.flashcardm.core.usecase
 
+import androidx.lifecycle.LiveData
 import com.faust.m.flashcardm.core.data.CardRepository
 import com.faust.m.flashcardm.core.domain.Card
+import com.faust.m.flashcardm.core.domain.Deck
 
 class CardUseCases private constructor(val addCard: AddCard,
                                        val deleteCards: DeleteCards,
-                                       val getCardsForBooklet: GetCardsForBooklet,
+                                       val getLiveDeck: GetLiveDeck,
                                        val updateCard: UpdateCard,
                                        val updateCardContent: UpdateCardContent) {
 
     constructor(cardRepository: CardRepository): this(
         AddCard(cardRepository),
         DeleteCards(cardRepository),
-        GetCardsForBooklet(cardRepository),
+        GetLiveDeck(cardRepository),
         UpdateCard(cardRepository),
         UpdateCardContent(cardRepository)
     )
@@ -25,18 +27,15 @@ class AddCard(private val cardRepository: CardRepository) {
 
 class DeleteCards(private val cardRepository: CardRepository) {
 
-    operator fun invoke(cards :List<Card>): Int = cardRepository.deleteCards(cards)
+    operator fun invoke(cards: List<Card>): Int = cardRepository.deleteCards(cards)
 }
 
-class GetCardsForBooklet(private val cardRepository: CardRepository) {
+class GetLiveDeck(private val cardRepository: CardRepository) {
 
-    operator fun invoke(bookletId: Long, filterReviewCard: Boolean = false): List<Card> =
-        cardRepository.getAllCardsForBooklet(bookletId).run {
-            when {
-                filterReviewCard -> filter(Card::needReview)
-                else -> this
-            }
-        }
+    operator fun invoke(bookletId: Long,
+                        attachCardContent: Boolean = false,
+                        filterToReviewCard: Boolean = false): LiveData<Deck> =
+        cardRepository.getLiveDeckForBooklet(bookletId, attachCardContent, filterToReviewCard)
 }
 
 class UpdateCard(private val cardRepository: CardRepository) {

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/PresentationExtensions.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/PresentationExtensions.kt
@@ -104,6 +104,25 @@ open class MutableLiveList<T>: MutableLiveData<MutableList<T>>() {
     }
 }
 
+/**
+ * MutableLiveSet is a mutable set that can be used as a liveData. Observers will be called
+ * only when there is an addition to the set.
+ * (Probably could be refactored to also trigger when an object is removed from the set, I'll see
+ * to it when I actually need that functionality)
+ */
+class MutableLiveSet<T> private constructor(private val inner :HashSet<T>) :
+    MutableLiveData<MutableSet<T>>(HashSet()), MutableSet<T> by inner {
+
+    constructor(): this(HashSet())
+
+    override fun add(element: T): Boolean {
+        val result = inner.add(element)
+        if (result)
+            postValue(value)
+        return result
+    }
+}
+
 class MutableLiveEvent<T>: MutableLiveData<Event<T>>() {
 
     fun postEvent(event: T) {

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/booklet/BookletActivity.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/booklet/BookletActivity.kt
@@ -28,7 +28,6 @@ class BookletActivity: AppCompatActivity(), LiveDataObserver {
 
         viewModel = getKoin().get<BookletViewModelFactory>().createViewModelFrom(this)
         viewModel.cardEditionState.observeData(this, ::onCardEditionStateChanged)
-        viewModel.loadData()
     }
 
     private fun onCardEditionStateChanged(cardEditionState: CardEditionState) =

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/fragment_edit_card/ViewModelEditCard.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/fragment_edit_card/ViewModelEditCard.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.faust.m.flashcardm.core.domain.Card
 import com.faust.m.flashcardm.core.usecase.CardUseCases
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.jetbrains.anko.AnkoLogger
@@ -37,11 +35,6 @@ interface ViewModelEditCard {
     val cardToEdit: LiveData<Card?>
     val cardEditionState: LiveData<CardEditionState>
 
-    var onCardCreated: ((newCard: Card) -> Unit)?
-    var onCardEdited: ((editedCard: Card) -> Unit)?
-
-    fun parentScope(): CoroutineScope?
-
     fun addCard(front: String, back: String)
     fun editCard(front: String, back: String)
     fun startCardAddition()
@@ -64,12 +57,7 @@ class DelegateEditCard(private val bookletId: Long): ViewModelEditCard, KoinComp
     private val _cardToEdit: MutableLiveData<Card?> = MutableLiveData()
     override val cardToEdit: LiveData<Card?> = _cardToEdit
 
-    override var onCardCreated: ((newCard: Card) -> Unit)? = null
-    override var onCardEdited: ((editedCard: Card) -> Unit)? = null
-
-
-    override fun parentScope(): CoroutineScope? = null
-
+    
     override fun addCard(front: String, back: String) {
         _cardToEdit.value?.let {
             it.addFrontAsText(front)
@@ -78,7 +66,6 @@ class DelegateEditCard(private val bookletId: Long): ViewModelEditCard, KoinComp
                 cardUseCases.addCard(it).also { newCard ->
                     verbose { "Created a new card: $newCard" }
                     _cardToEdit.postValue(Card(bookletId = bookletId))
-                    onCardCreated?.invoke(newCard)
                 }
             }
         }
@@ -91,7 +78,6 @@ class DelegateEditCard(private val bookletId: Long): ViewModelEditCard, KoinComp
             GlobalScope.launch {
                 cardUseCases.updateCardContent(cardToUpdate).also { updatedCard ->
                     verbose { "Updated a card: $updatedCard" }
-                    onCardEdited?.invoke(updatedCard)
                 }
             }
         }

--- a/app/src/main/java/com/faust/m/flashcardm/presentation/review/ReviewActivity.kt
+++ b/app/src/main/java/com/faust/m/flashcardm/presentation/review/ReviewActivity.kt
@@ -30,7 +30,6 @@ class ReviewActivity: AppCompatActivity(), LiveDataObserver {
             getKoin().get<BookletViewModelFactory>().createViewModelFrom(this)
         viewModel.reviewCard.observeData(this, ::onCurrentCardChanged)
         viewModel.cardEditionState.observeData(this, ::onCardEditionStateChanged)
-        viewModel.loadData()
     }
 
     private fun onCurrentCardChanged(reviewCard: ReviewCard) {


### PR DESCRIPTION
- Clean BookletUseCaseTest: use the new OntTimeObserverRule
- Add MutableLiveSet which trigger observer when adding object to the
set
- Refactor BookletViewModel to use liveData from room for cards in deck
- Refactor ReviewViewModel to use liveData from room for cards in deck